### PR TITLE
Guard service worker registration and protocol

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -44,7 +44,7 @@
     <WikiPage />
   </div>
   <script type="module" src="app.js"></script>
-  <script>
+  <script type="module">
     const chip = document.getElementById('mode-chip')
     const modal = document.getElementById('mode-modal')
     const confirmBtn = document.getElementById('mode-confirm')
@@ -79,7 +79,7 @@
       document.getElementById('status').textContent = 'Starting...';
     });
 
-    if ('serviceWorker' in navigator) {
+    if ('serviceWorker' in navigator && import.meta.env.PROD) {
       window.addEventListener('load', () => {
         navigator.serviceWorker.register('/sw.js').then(reg => {
           if (reg.waiting) notifyUpdate(reg.waiting)

--- a/app/sw.js
+++ b/app/sw.js
@@ -10,6 +10,8 @@ self.addEventListener('activate', event => {
 
 self.addEventListener('fetch', event => {
   if (event.request.method !== 'GET') return;
+  const url = new URL(event.request.url);
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return;
   event.respondWith(
     caches.match(event.request).then(cached => {
       if (cached) return cached;


### PR DESCRIPTION
## Summary
- avoid caching non-http requests in service worker
- register service worker only in production

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a45483f1688333b6bd3dae3b80c260