### PR TITLE
Configure API status URL via env and Vite proxy

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -72,12 +72,23 @@
       })
     }
 
-    fetch('/status').then(r => r.json()).then(d => {
-      document.getElementById('status').textContent = `LLM loaded: ${d.llm_loaded}, docs indexed: ${d.docs_indexed}`;
-      setTimeout(() => document.getElementById('splash').style.display = 'none', 1000);
-    }).catch(() => {
-      document.getElementById('status').textContent = 'Starting...';
-    });
+    const apiBase = (import.meta.env.VITE_API_BASE ?? 'http://localhost:8001/api')
+      .replace(/\/api$/, '')
+
+    fetch(`${apiBase}/status`)
+      .then(r => r.json())
+      .then(d => {
+        document.getElementById('status').textContent =
+          `LLM loaded: ${d.llm_loaded}, docs indexed: ${d.docs_indexed}`
+      })
+      .catch(() => {
+        document.getElementById('status').textContent = 'Starting...'
+      })
+      .finally(() =>
+        setTimeout(() =>
+          document.getElementById('splash').style.display = 'none',
+        1000)
+      )
 
     if ('serviceWorker' in navigator && import.meta.env.PROD) {
       window.addEventListener('load', () => {

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -2,5 +2,10 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
 export default defineConfig({
-  plugins: [vue()]
+  plugins: [vue()],
+  server: {
+    proxy: {
+      '/status': 'http://localhost:8001'
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- Use configurable API base to fetch status in index.html
- Proxy `/status` to backend in Vite dev server

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5956e24f8833383e1bbc960585ef3