### PR TITLE
Configure API status URL via env and Vite proxy

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -2,14 +2,16 @@ import { createApp, ref } from 'https://unpkg.com/vue@3/dist/vue.esm-browser.js'
 import { useFetch } from './composables/useFetch.js'
 import WikiPage from './components/WikiPage.vue'
 
+const apiBase = import.meta.env.VITE_API_BASE ?? 'http://localhost:8001/api'
+
 createApp({
   setup() {
     const username = ref('')
     const password = ref('')
     const success = ref(false)
 
-    const { data, error, loading, fetchData } = useFetch(
-      '/api/auth/login',
+    const { error, loading, fetchData } = useFetch(
+      `${apiBase}/auth/login`,
       { method: 'POST', headers: { 'Content-Type': 'application/json' } }
     )
 

--- a/app/index.html
+++ b/app/index.html
@@ -23,6 +23,11 @@
     <div id="status">Starting...</div>
   </div>
   <div id="app" class="w-80 bg-white p-4 rounded shadow" v-if="!success">
+    <h1 class="text-xl font-bold mb-2 text-center">Frank The Local LLM</h1>
+    <p class="text-sm text-gray-600 mb-4">
+      Enter your credentials to continue. Choose Desktop if running the
+      Tauri app, otherwise pick Browser when prompted above.
+    </p>
     <form @submit.prevent="submit">
       <div class="mb-4">
         <label class="block mb-1">Username</label>
@@ -72,12 +77,23 @@
       })
     }
 
-    fetch('/status').then(r => r.json()).then(d => {
-      document.getElementById('status').textContent = `LLM loaded: ${d.llm_loaded}, docs indexed: ${d.docs_indexed}`;
-      setTimeout(() => document.getElementById('splash').style.display = 'none', 1000);
-    }).catch(() => {
-      document.getElementById('status').textContent = 'Starting...';
-    });
+    const apiBase = (import.meta.env.VITE_API_BASE ?? 'http://localhost:8001/api')
+      .replace(/\/api$/, '')
+
+    fetch(`${apiBase}/status`)
+      .then(r => r.json())
+      .then(d => {
+        document.getElementById('status').textContent =
+          `LLM loaded: ${d.llm_loaded}, docs indexed: ${d.docs_indexed}`
+      })
+      .catch(() => {
+        document.getElementById('status').textContent = 'Backend unavailable'
+      })
+      .finally(() =>
+        setTimeout(() =>
+          document.getElementById('splash').style.display = 'none',
+        1000)
+      )
 
     if ('serviceWorker' in navigator && import.meta.env.PROD) {
       window.addEventListener('load', () => {

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -2,5 +2,11 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
 export default defineConfig({
-  plugins: [vue()]
+  plugins: [vue()],
+  server: {
+    proxy: {
+      '/status': 'http://localhost:8001',
+      '/api': 'http://localhost:8001'
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- Use VITE_API_BASE for login requests
- Explain login screen and show backend availability
- Proxy `/api` and `/status` to backend in Vite dev server

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5956e24f8833383e1bbc960585ef3