### PR TITLE
Configure API status URL via env and Vite proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,16 @@ troubleshooting.
 2. In your browser open the served page. The client expects the FastAPI backend
     to be available at `http://localhost:8001/api`.
     When started the server tries to bind to port `8001` but if it is already
-
    taken the process automatically increments the port until a free one is
    found. Set the `PORT` environment variable to force a specific port or edit
    `backend/app/config.py`.
+
+    The login screen includes pre-filled test credentials:
+
+    - **Username:** `testuser`
+    - **Password:** `testpass`
+
+    These are intended for local development only; change them for production.
 
 You can modify `app/index.html` and `app/app.js` to tweak the UI or add new
 components.

--- a/app/app.js
+++ b/app/app.js
@@ -4,12 +4,14 @@ import WikiPage from './components/WikiPage.vue'
 
 createApp({
   setup() {
-    const username = ref('')
-    const password = ref('')
+    // Default test credentials so the login form is pre-filled during demos.
+    // Replace or remove for production deployments.
+    const username = ref('testuser')
+    const password = ref('testpass')
     const success = ref(false)
 
-    const { data, error, loading, fetchData } = useFetch(
-      '/api/auth/login',
+    const { error, loading, fetchData } = useFetch(
+      '/auth/login',
       { method: 'POST', headers: { 'Content-Type': 'application/json' } }
     )
 

--- a/app/components/Dashboard.vue
+++ b/app/components/Dashboard.vue
@@ -11,7 +11,7 @@ defineOptions({ name: 'AppDashboard' })
 import { onMounted } from 'vue'
 import { useFetch } from '../composables/useFetch'
 
-const { data: items, fetchData } = useFetch('/api/entries')
+const { data: items, fetchData } = useFetch('/entries')
 
 onMounted(() => {
   fetchData()

--- a/app/components/WikiPage.vue
+++ b/app/components/WikiPage.vue
@@ -22,7 +22,7 @@ const palette = ref(false)
 const settings = ref(false)
 const titles = ref([])
 
-const { data, fetchData } = useFetch('/api/entries')
+const { data, fetchData } = useFetch('/entries')
 
 onMounted(async () => {
   await fetchData()

--- a/app/index.html
+++ b/app/index.html
@@ -22,7 +22,13 @@
   <div id="splash" class="absolute inset-0 flex items-center justify-center bg-gray-100">
     <div id="status">Starting...</div>
   </div>
-  <div id="app" class="w-80 bg-white p-4 rounded shadow" v-if="!success">
+  <div id="app" class="w-full max-w-sm mx-auto bg-white p-6 rounded shadow" v-if="!success">
+    <h1 class="text-xl font-bold mb-2 text-center">Frank The Local LLM</h1>
+    <ol class="text-sm text-gray-600 mb-4 list-decimal list-inside">
+      <li>Confirm your environment when prompted (Desktop or Browser).</li>
+      <li>Use the pre-filled test credentials below.</li>
+      <li>Click <strong>Login</strong> to continue to the wiki.</li>
+    </ol>
     <form @submit.prevent="submit">
       <div class="mb-4">
         <label class="block mb-1">Username</label>
@@ -72,12 +78,23 @@
       })
     }
 
-    fetch('/status').then(r => r.json()).then(d => {
-      document.getElementById('status').textContent = `LLM loaded: ${d.llm_loaded}, docs indexed: ${d.docs_indexed}`;
-      setTimeout(() => document.getElementById('splash').style.display = 'none', 1000);
-    }).catch(() => {
-      document.getElementById('status').textContent = 'Starting...';
-    });
+    const apiBase = (import.meta.env.VITE_API_BASE ?? 'http://localhost:8001/api')
+      .replace(/\/api$/, '')
+
+    fetch(`${apiBase}/status`)
+      .then(r => r.json())
+      .then(d => {
+        document.getElementById('status').textContent =
+          `LLM loaded: ${d.llm_loaded}, docs indexed: ${d.docs_indexed}`
+      })
+      .catch(() => {
+        document.getElementById('status').textContent = 'Backend unavailable'
+      })
+      .finally(() =>
+        setTimeout(() =>
+          document.getElementById('splash').style.display = 'none',
+        1000)
+      )
 
     if ('serviceWorker' in navigator && import.meta.env.PROD) {
       window.addEventListener('load', () => {

--- a/app/tests/unit/useFetch.spec.js
+++ b/app/tests/unit/useFetch.spec.js
@@ -15,7 +15,7 @@ describe('useFetch', () => {
     const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) }))
     global.fetch = fetchMock
 
-    const { fetchData } = useFetch('/api/test')
+    const { fetchData } = useFetch('/test')
     const p = fetchData()
     vi.runAllTimers()
     await p

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -2,5 +2,11 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
 export default defineConfig({
-  plugins: [vue()]
+  plugins: [vue()],
+  server: {
+    proxy: {
+      '/status': 'http://localhost:8001',
+      '/api': 'http://localhost:8001'
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- Use VITE_API_BASE for login requests
- Explain login screen and show backend availability
- Proxy `/api` and `/status` to backend in Vite dev server
- Prefill login form with demo credentials and document them
- Avoid duplicating the `/api` prefix in login and entry fetches

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5956e24f8833383e1bbc960585ef3