### PR TITLE
Configure dev server and fix API path handling

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -2,8 +2,6 @@ import { createApp, ref } from 'https://unpkg.com/vue@3/dist/vue.esm-browser.js'
 import { useFetch } from './composables/useFetch.js'
 import WikiPage from './components/WikiPage.vue'
 
-const apiBase = import.meta.env.VITE_API_BASE ?? 'http://localhost:8001/api'
-
 createApp({
   setup() {
     // Default test credentials so the login form is pre-filled during demos.

--- a/app/components/ChatInterface.vue
+++ b/app/components/ChatInterface.vue
@@ -16,7 +16,7 @@ import { ref, nextTick } from 'vue'
 const message = ref('')
 const messages = ref([])
 const container = ref(null)
-const API_BASE = import.meta.env?.VITE_API_BASE || 'http://localhost:8001/api'
+const API_BASE = (import.meta.env?.VITE_API_BASE || '/api').replace(/\/$/, '')
 
 
 async function send () {

--- a/app/components/FileTree.vue
+++ b/app/components/FileTree.vue
@@ -35,7 +35,7 @@ const entries = ref([])
 const newTitle = ref('')
 const newGroup = ref('')
 const newContent = ref('')
-const API_BASE = import.meta.env?.VITE_API_BASE || 'http://localhost:8001/api'
+const API_BASE = (import.meta.env?.VITE_API_BASE || '/api').replace(/\/$/, '')
 
 
 const groups = computed(() => {

--- a/app/composables/useFetch.js
+++ b/app/composables/useFetch.js
@@ -32,8 +32,13 @@ export function useFetch (url, options = {}, config = {}) {
     let attempt = 0
     while (attempt <= retries) {
       try {
-        const base = import.meta.env?.VITE_API_BASE || 'http://localhost:8001/api'
-        const target = url.startsWith('http') ? url : base + url
+        const base = (import.meta.env?.VITE_API_BASE || '/api').replace(/\/$/, '')
+        const path = url.startsWith('/') ? url : `/${url}`
+        const target = url.startsWith('http')
+          ? url
+          : base.endsWith('/api') && path.startsWith('/api')
+            ? base + path.slice(4)
+            : base + path
         const resp = await fetch(target, opts)
         if (!resp.ok) throw new Error(resp.statusText)
         data.value = await resp.json()

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -4,11 +4,23 @@ import vue from '@vitejs/plugin-vue'
 export default defineConfig({
   plugins: [vue()],
   server: {
+    open: '/index.html',
+    port: 5173,
+    strictPort: true,
+    hmr: {
+      clientPort: 5173
+    },
     proxy: {
-
-      '/status': 'http://localhost:8001',
-      '/api': 'http://localhost:8001'
-
+      '/api': {
+        target: 'http://localhost:8001',
+        changeOrigin: true,
+        rewrite: path => path.replace(/^\/api/, ''),
+        ws: true
+      },
+      '/status': {
+        target: 'http://localhost:8001',
+        changeOrigin: true
+      }
     }
   }
 })


### PR DESCRIPTION
## Summary
- Configure Vite dev server to open index.html, use a fixed HMR port, and proxy API & status routes with WebSocket support
- Normalize API base path in fetch composable to avoid duplicate `/api` segments
- Align Vue components with new API base handling

## Testing
- `npm test`
- `npm run lint` *(fails: 80 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a64048890483338e0b8bb641d57eab