### PR TITLE
Allow configuring LLM and embedding models via settings

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -9,6 +9,7 @@ class Settings(BaseSettings):
     redis_url: str = "redis://localhost:6379/0"
     database_url: str = "sqlite:///./app.db"
     model: str = "llama3"
+    embed_model: str = "nomic-embed-text"
     retrieval_k: int = 8
     chunk_size: int = 512
 

--- a/backend/app/services/agent_service.py
+++ b/backend/app/services/agent_service.py
@@ -6,17 +6,19 @@ from langchain_community.llms import Ollama
 from langchain_experimental.sql import SQLDatabaseChain
 
 from ..db import engine
+from ..config import Settings
 
 router = APIRouter(tags=["agent"], prefix="/agent")
 
 _AGENT = None
 _CHAIN = None
+settings = Settings()
 
 def get_agent():
     global _AGENT
     if _AGENT is None:
         db = SQLDatabase(engine)
-        llm = Ollama(model="llama3")
+        llm = Ollama(model=settings.model)
         _AGENT = create_sql_agent(llm=llm, db=db, agent_type="openai-tools")
     return _AGENT
 
@@ -25,7 +27,7 @@ def get_chain():
     global _CHAIN
     if _CHAIN is None:
         db = SQLDatabase(engine)
-        llm = Ollama(model="llama3")
+        llm = Ollama(model=settings.model)
         _CHAIN = SQLDatabaseChain.from_llm(llm, db, return_intermediate_steps=True)
     return _CHAIN
 

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -5,8 +5,10 @@ import json
 
 from fastapi import APIRouter, Body, HTTPException
 from langchain_community.llms import Ollama
+from ..config import Settings
 
 router = APIRouter(tags=["chat"], prefix="/chat")
+settings = Settings()
 
 _CACHE_FILE = Path(__file__).resolve().parents[1] / "data" / "chat_cache.json"
 
@@ -17,7 +19,7 @@ class ChatService:
 
     def __init__(self) -> None:
         if self._llm is None:
-            self._llm = Ollama(model="llama3")
+            self._llm = Ollama(model=settings.model)
         if self._cache is None:
             self._cache = _load_cache()
 

--- a/backend/app/services/qa_service.py
+++ b/backend/app/services/qa_service.py
@@ -15,7 +15,7 @@ settings = Settings()
 
 
 def _chain():
-    embeddings = OllamaEmbeddings(model="nomic-embed-text")
+    embeddings = OllamaEmbeddings(model=settings.embed_model)
     vs = PGVector(
         connection_string=settings.database_url,
         embedding_function=embeddings,

--- a/backend/app/services/sql_service.py
+++ b/backend/app/services/sql_service.py
@@ -2,16 +2,18 @@ from fastapi import APIRouter, Body, HTTPException, Depends
 from langchain_community.agent_toolkits.sql.base import create_sql_agent
 from langchain_community.utilities import SQLDatabase
 from langchain_community.llms import Ollama
+from ..config import Settings
 
 from ..db import engine
 from . import CachedLLMService
 
 router = APIRouter(tags=["sql"], prefix="/sql")
+settings = Settings()
 
 
 class SQLService(CachedLLMService):
     def __init__(self):
-        super().__init__(Ollama(model="llama3"))
+        super().__init__(Ollama(model=settings.model))
         self._db = SQLDatabase(engine)
         self._agent = create_sql_agent(llm=self._llm, db=self._db, agent_type="openai-tools")
 

--- a/backend/app/services/trivia_service.py
+++ b/backend/app/services/trivia_service.py
@@ -7,22 +7,24 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.vectorstores import Chroma
 from langchain_community.embeddings import OllamaEmbeddings
 from langchain_community.llms import Ollama
+from ..config import Settings
 
 from . import CachedLLMService
 
 router = APIRouter()
 
 DATA_FILE = Path(__file__).resolve().parents[1] / "data" / "trivia.md"
+settings = Settings()
 
 
 class TriviaService(CachedLLMService):
     def __init__(self):
-        super().__init__(Ollama())
+        super().__init__(Ollama(model=settings.model))
         loader = UnstructuredMarkdownLoader(str(DATA_FILE))
         docs = loader.load()
         splitter = RecursiveCharacterTextSplitter(chunk_size=512, chunk_overlap=50)
         splits = splitter.split_documents(docs)
-        embeddings = OllamaEmbeddings(model="nomic-embed-text")
+        embeddings = OllamaEmbeddings(model=settings.embed_model)
         vectorstore = Chroma.from_documents(splits, embeddings)
         self._chain = RetrievalQA.from_chain_type(llm=self._llm, retriever=vectorstore.as_retriever())
 

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -24,7 +24,7 @@ celery_app.conf.beat_schedule = {
 }
 
 
-summarization_service = SummarizationService(OllamaLLM())
+summarization_service = SummarizationService(OllamaLLM(settings.model))
 
 
 @celery_app.task
@@ -44,7 +44,7 @@ def embed_chunk(chunk_id: int):
         chunk = db.query(models.Chunk).get(chunk_id)
         if chunk is None:
             return
-        embeddings = OllamaEmbeddings(model="nomic-embed-text")
+        embeddings = OllamaEmbeddings(model=settings.embed_model)
         vector = embeddings.embed_query(chunk.content)
         emb = models.Embedding(chunk_id=chunk.id, vector=vector)
         db.add(emb)

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -8,8 +8,10 @@ from langchain_community.llms import Ollama
 
 from .db import SessionLocal
 from .models import User
+from .config import Settings
 
 celery_app = Celery("worker", broker="redis://localhost:6379/0")
+settings = Settings()
 
 _STATE_FILE = Path(__file__).resolve().parents[1] / "data" / "summary_state.json"
 _SUMMARY_FILE = Path(__file__).resolve().parents[1] / "data" / "user_summaries.json"
@@ -45,7 +47,7 @@ def summarize_new_users():
     if not users:
         return "No new users"
 
-    llm = Ollama(model="llama3")
+    llm = Ollama(model=settings.model)
     content = "\n".join(u.username for u in users)
     summary = llm.invoke(f"Summarize the following new users:\n{content}")
 


### PR DESCRIPTION
## Summary
- add `embed_model` setting and use `settings.model`
- replace hard-coded model names in services and tasks

## Testing
- `pytest`
- `CI=1 yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a8cb881f1c8333bbe16df73ec64f72