### PR TITLE
fix: use configured FastAPI app in entrypoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,15 +1,25 @@
-import os
+"""Entry point for launching the full FastAPI application.
+
+This module simply exposes the application defined in ``app`` and binds it to
+an available port.  Previously this file constructed a bare ``FastAPI``
+instance with a single ``/`` route, which meant running ``python main.py`` did
+not expose any of the routers described in ``agents.md`` such as the status
+endpoint.
+
+Importing the application from :mod:`app` ensures the CLI entry point mirrors
+the behaviour of the package and keeps the executable aligned with the
+AGENTS.md specification.
+"""
+
 import socket
-from fastapi import FastAPI
+
 import uvicorn
 
-app = FastAPI()
-
-@app.get("/")
-async def root():
-    return {"message": "hello"}
+from app import app  # Import the fully configured FastAPI app
 
 def get_free_port() -> int:
+    """Return an available port bound to localhost."""
+
     with socket.socket() as s:
         s.bind(("localhost", 0))
         return s.getsockname()[1]


### PR DESCRIPTION
## Summary
- launch backend using the fully configured app so all routes, like `/status`, are available when running `backend/main.py`

## Testing
- `pytest`
- `yarn test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d2179f7c83339375fa45cb415103