### PR TITLE
Restrict CORS to local hosts and externalize JWT secret

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -5,13 +5,14 @@ class Settings(BaseSettings):
     host: str = "0.0.0.0"
     port: int = 8001
     debug: bool = False
-    allowed_origins: list[str] = ["*"]
+    allowed_origins: list[str] = ["http://localhost:5173", "tauri://localhost"]
     redis_url: str = "redis://localhost:6379/0"
     database_url: str = "sqlite:///./app.db"
     model: str = "llama3"
     embed_model: str = "nomic-embed-text"
     retrieval_k: int = 8
     chunk_size: int = 512
+    secret_key: str = "super-secret-key"
 
     class Config:
         env_file = ".env"

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -6,7 +6,10 @@ from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt
 from passlib.context import CryptContext
 
-SECRET_KEY = "super-secret-key"  # In production use environment variable
+from .config import Settings
+
+settings = Settings()
+SECRET_KEY = settings.secret_key
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
 


### PR DESCRIPTION
## Summary
- limit allowed CORS origins to local frontend and Tauri clients
- load JWT secret from settings for easier configuration

## Testing
- `pytest backend/tests`
- `yarn test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d3b91db48333a17a119a0669da37