### PR TITLE
Avoid splash hang and load wiki without auth

### DIFF
--- a/app/components/WikiPage.vue
+++ b/app/components/WikiPage.vue
@@ -24,9 +24,10 @@ const titles = ref([])
 
 const { data, fetchData } = useFetch('/entries')
 
-onMounted(async () => {
-  await fetchData()
-  titles.value = (data.value || []).map(e => e.content.split('\n')[0])
+onMounted(() => {
+  fetchData().then(() => {
+    titles.value = (data.value || []).map(e => e.content.split('\n')[0])
+  })
 })
 
 window.addEventListener('keydown', e => {

--- a/app/index.html
+++ b/app/index.html
@@ -55,20 +55,23 @@
     const apiBase = (import.meta.env.VITE_API_BASE ?? 'http://localhost:8001')
       .replace(/\/$/, '')
 
-    fetch(`${apiBase}/status`)
+    const splash = document.getElementById('splash')
+    const statusEl = document.getElementById('status')
+    const hideSplash = () => { splash.style.display = 'none' }
+
+    const controller = new AbortController()
+    setTimeout(() => controller.abort(), 1000)
+
+    fetch(`${apiBase}/status`, { signal: controller.signal })
       .then(r => r.json())
       .then(d => {
-        document.getElementById('status').textContent =
+        statusEl.textContent =
           `LLM loaded: ${d.llm_loaded}, docs indexed: ${d.docs_indexed}`
       })
       .catch(() => {
-        document.getElementById('status').textContent = 'Backend unavailable'
+        statusEl.textContent = 'Backend unavailable'
       })
-      .finally(() =>
-        setTimeout(() =>
-          document.getElementById('splash').style.display = 'none',
-        1000)
-      )
+      .finally(hideSplash)
 
     if ('serviceWorker' in navigator && import.meta.env.PROD) {
       window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- Avoid splash screen hanging by aborting status check after one second
- Fetch entry titles without blocking wiki UI mounting

## Testing
- `yarn lint`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68a9889682ac833393a1a909918ad123