### PR TITLE
Refactor Windows bootstrap and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ so other operating systems require a different setup:
 ./run_all.sh
 ```
 
+If the system Python is outdated, upgrade `pip` beforehand to avoid modification errors:
+
+```bash
+python -m pip install --upgrade pip
+```
+
 You can also manage the stack manually:
 
 ```bash
@@ -198,12 +204,14 @@ The script sequentially builds the .NET console app, installs Python dependencie
 On Windows run the commands from `run_all.sh` one by one in PowerShell (first `cd app`, then `npm install && npm run dev`) or execute the script in WSL. Running them in order ensures all dependencies are restored.
 
 
-Background tasks that summarize entries can be started separately using
+Background tasks that summarize entries can be started separately. Ensure a Redis
+server is reachable on `localhost:6379` and launch the worker and beat processes:
 
 ```bash
-celery -A backend.app.tasks worker --beat
+celery -A backend.app.tasks worker
+celery -A backend.app.tasks beat
 ```
-The worker also schedules a nightly digest summarizing new chunks and maintains
+The worker schedules a nightly digest summarizing new chunks and maintains
 wiki-style backlinks between notes.
 
 ### Importing Data

--- a/frank_up.ps1
+++ b/frank_up.ps1
@@ -52,7 +52,7 @@ if (Get-Service redis -ErrorAction SilentlyContinue) {
     $redisOut = Join-Path $LogDir 'redis.out.log'
     $redisErr = Join-Path $LogDir 'redis.err.log'
     Remove-Item $redisOut, $redisErr -ErrorAction SilentlyContinue
-    Start-Process redis-server -WindowStyle Hidden -RedirectStandardOutput $redisOut -RedirectStandardError $redisErr
+    Start-Process redis-server -RedirectStandardOutput $redisOut -RedirectStandardError $redisErr
 
 }
 
@@ -63,7 +63,7 @@ if (Get-Service ollama -ErrorAction SilentlyContinue) {
     $ollamaOut = Join-Path $LogDir 'ollama.out.log'
     $ollamaErr = Join-Path $LogDir 'ollama.err.log'
     Remove-Item $ollamaOut, $ollamaErr -ErrorAction SilentlyContinue
-    Start-Process ollama -ArgumentList 'serve' -WindowStyle Hidden -RedirectStandardOutput $ollamaOut -RedirectStandardError $ollamaErr
+    Start-Process ollama -ArgumentList 'serve' -RedirectStandardOutput $ollamaOut -RedirectStandardError $ollamaErr
 
 }
 
@@ -97,7 +97,7 @@ Free-Port $backendPort
 $backendOut = Join-Path $LogDir 'backend.out.log'
 $backendErr = Join-Path $LogDir 'backend.err.log'
 Remove-Item $backendOut, $backendErr -ErrorAction SilentlyContinue
-$backend = Start-Process python -ArgumentList @('-m','backend.app.main') -RedirectStandardOutput $backendOut -RedirectStandardError $backendErr -WindowStyle Hidden -PassThru
+$backend = Start-Process python -ArgumentList @('-m','backend.app.main') -RedirectStandardOutput $backendOut -RedirectStandardError $backendErr -PassThru
 if ($backend) {
   $backend.Id | Out-File (Join-Path $LogDir 'backend.pid')
 } else {
@@ -116,7 +116,7 @@ for ($i=0; $i -lt 30; $i++) {
 $celeryWOut = Join-Path $LogDir 'celery_worker.out.log'
 $celeryWErr = Join-Path $LogDir 'celery_worker.err.log'
 Remove-Item $celeryWOut, $celeryWErr -ErrorAction SilentlyContinue
-$celeryWorker = Start-Process celery -ArgumentList @('-A','backend.app.tasks','worker') -RedirectStandardOutput $celeryWOut -RedirectStandardError $celeryWErr -WindowStyle Hidden -PassThru
+$celeryWorker = Start-Process celery -ArgumentList @('-A','backend.app.tasks','worker') -RedirectStandardOutput $celeryWOut -RedirectStandardError $celeryWErr -PassThru
 if ($celeryWorker) {
   $celeryWorker.Id | Out-File (Join-Path $LogDir 'celery_worker.pid')
 } else {
@@ -126,7 +126,7 @@ if ($celeryWorker) {
 $celeryBOut = Join-Path $LogDir 'celery_beat.out.log'
 $celeryBErr = Join-Path $LogDir 'celery_beat.err.log'
 Remove-Item $celeryBOut, $celeryBErr -ErrorAction SilentlyContinue
-$celeryBeat = Start-Process celery -ArgumentList @('-A','backend.app.tasks','beat') -RedirectStandardOutput $celeryBOut -RedirectStandardError $celeryBErr -WindowStyle Hidden -PassThru
+$celeryBeat = Start-Process celery -ArgumentList @('-A','backend.app.tasks','beat') -RedirectStandardOutput $celeryBOut -RedirectStandardError $celeryBErr -PassThru
 if ($celeryBeat) {
   $celeryBeat.Id | Out-File (Join-Path $LogDir 'celery_beat.pid')
 } else {
@@ -134,9 +134,10 @@ if ($celeryBeat) {
 }
 
 # .NET console app
-$dotnetOut = Join-Path $LogDir 'dotnet.log'
-Remove-Item $dotnetOut -ErrorAction SilentlyContinue
-$dotnet = Start-Process dotnet -ArgumentList @('run','--project','src/ConsoleApp/ConsoleApp.csproj') -RedirectStandardOutput $dotnetOut -RedirectStandardError $dotnetOut -WindowStyle Hidden -PassThru
+$dotnetOut = Join-Path $LogDir 'dotnet.out.log'
+$dotnetErr = Join-Path $LogDir 'dotnet.err.log'
+Remove-Item $dotnetOut, $dotnetErr -ErrorAction SilentlyContinue
+$dotnet = Start-Process dotnet -ArgumentList @('run','--project','src/ConsoleApp/ConsoleApp.csproj') -RedirectStandardOutput $dotnetOut -RedirectStandardError $dotnetErr -PassThru
 if ($dotnet) {
   $dotnet.Id | Out-File (Join-Path $LogDir 'dotnet.pid')
 } else {
@@ -148,7 +149,7 @@ npm --prefix $frontDir install | Out-Null
 $frontOut = Join-Path $LogDir 'frontend.out.log'
 $frontErr = Join-Path $LogDir 'frontend.err.log'
 Remove-Item $frontOut, $frontErr -ErrorAction SilentlyContinue
-$frontend = Start-Process node -WorkingDirectory $frontDir -ArgumentList @('esbuild.config.js','--serve') -RedirectStandardOutput $frontOut -RedirectStandardError $frontErr -WindowStyle Hidden -PassThru
+$frontend = Start-Process node -WorkingDirectory $frontDir -ArgumentList @('esbuild.config.js','--serve') -RedirectStandardOutput $frontOut -RedirectStandardError $frontErr -PassThru
 if ($frontend) {
   $frontend.Id | Out-File (Join-Path $LogDir 'frontend.pid')
 } else {

--- a/run_all.sh
+++ b/run_all.sh
@@ -76,7 +76,7 @@ fi
   source "$VENV_ACTIVATE"
   pip install --upgrade pip
   pip install -r "$ROOT/backend/requirements.txt"
-  $PYTHON_BIN "$ROOT/backend/app/manage.py" migrate
+  $PYTHON_BIN -m backend.app.manage migrate
 ) 2>&1 | tee -a "$LOG_DIR/backend-build.log" || true
 
 if [[ $PLATFORM == "ubuntu" ]]; then


### PR DESCRIPTION
## Summary
- clean up `frank_up.ps1` by removing conflicting window flags and using distinct stdout/stderr logs for each process
- invoke Django-style manage script as a module in `run_all.sh`
- document upgrading pip and running Celery worker/beat separately with Redis

## Testing
- `npm test` *(tests passed; cancelled watch mode)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa1b1e6cec8333a854edfb16c2181e