### PR TITLE
docs: clarify pip upgrade and celery requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,14 +110,23 @@ A simple FastAPI backend is located in the `backend/` directory. The configurati
 ### Setup
 
 1. Install Python 3.11 or newer.
-2. Install dependencies:
+2. Upgrade `pip` and install dependencies:
    ```bash
+   python -m pip install --upgrade pip
    pip install -r backend/requirements.txt
    ```
 3. Run the server:
    ```bash
    python -m backend.app.main
    ```
+
+When running management commands such as database migrations, invoke them as modules:
+
+```bash
+python -m backend.app.manage <command>
+```
+
+Executing `manage.py` directly can trigger an "attempted relative import with no known parent package" error.
 
 The server exposes a sample endpoint at `/api/hello` returning a welcome message.
 
@@ -205,14 +214,18 @@ On Windows run the commands from `run_all.sh` one by one in PowerShell (first `c
 
 
 Background tasks that summarize entries can be started separately. Ensure a Redis
-server is reachable on `localhost:6379` and launch the worker and beat processes:
+server is running and reachable on `redis://localhost:6379/0`, then launch the worker
+and beat processes in separate terminals:
 
 ```bash
 celery -A backend.app.tasks worker
 celery -A backend.app.tasks beat
 ```
 The worker schedules a nightly digest summarizing new chunks and maintains
-wiki-style backlinks between notes.
+wiki-style backlinks between notes. On Windows the combined `celery -B` mode is
+unsupported; starting the worker and beat separately avoids errors. If the
+logs show connection refusals to Redis, ensure the Redis server is running or
+update `REDIS_URL` to point to an accessible broker.
 
 ### Importing Data
 

--- a/docs/README-local-dev.md
+++ b/docs/README-local-dev.md
@@ -7,6 +7,7 @@ This short guide explains how to run the entire project locally without any pack
 - Python 3.11+
 - Node.js (for the Vue frontend)
 - The .NET 8 SDK (optional but recommended)
+- Redis server (for Celery tasks)
 
 ## Quick Start
 
@@ -34,6 +35,7 @@ If you prefer to run each component manually:
 
 ```bash
 # Backend
+python -m pip install --upgrade pip
 pip install -r backend/requirements.txt
 python -m backend.app.main
 
@@ -52,5 +54,25 @@ node ../server.js
 dotnet build src/ConsoleAppSolution.sln -c Release
 dotnet run --project src/ConsoleApp/ConsoleApp.csproj
 ```
+
+To run database migrations or other management commands, invoke them as modules:
+
+```bash
+python -m backend.app.manage <command>
+```
+
+Directly executing `manage.py` can raise an "attempted relative import with no known parent package" error.
+
+## Background tasks
+
+Celery uses Redis as its broker. Ensure a Redis server is running and start the worker and beat schedulers in separate terminals:
+
+```bash
+redis-server &   # or ensure the Redis service is running
+celery -A backend.app.tasks worker
+celery -A backend.app.tasks beat
+```
+
+On Windows the combined `celery -B` mode is unsupported; running the worker and beat separately avoids issues. If Celery logs connection refusals to `redis://localhost:6379/0`, verify that Redis is reachable or update `REDIS_URL`.
 
 The default UI is served at `http://localhost:5173` (or `http://localhost:8080` when serving the built bundle).


### PR DESCRIPTION
## Summary
- document upgrading pip before installing backend dependencies
- explain running management commands with `python -m` to avoid relative import errors
- add Redis and separate Celery worker/beat instructions for background tasks

## Testing
- `scripts/test_pipeline.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aa22cd5cec8333b091e3aa16bae42a