### PR TITLE
docs: clarify pip upgrade and celery requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,14 +110,23 @@ A simple FastAPI backend is located in the `backend/` directory. The configurati
 ### Setup
 
 1. Install Python 3.11 or newer.
-2. Install dependencies:
+2. Upgrade `pip` and install dependencies:
    ```bash
+   python -m pip install --upgrade pip
    pip install -r backend/requirements.txt
    ```
 3. Run the server:
    ```bash
    python -m backend.app.main
    ```
+
+When running management commands such as database migrations, invoke them as modules:
+
+```bash
+python -m backend.app.manage <command>
+```
+
+Executing `manage.py` directly can trigger an "attempted relative import with no known parent package" error.
 
 The server exposes a sample endpoint at `/api/hello` returning a welcome message.
 
@@ -205,14 +214,18 @@ On Windows run the commands from `run_all.sh` one by one in PowerShell (first `c
 
 
 Background tasks that summarize entries can be started separately. Ensure a Redis
-server is reachable on `localhost:6379` and launch the worker and beat processes:
+server is running and reachable on `redis://localhost:6379/0`, then launch the worker
+and beat processes in separate terminals:
 
 ```bash
 celery -A backend.app.tasks worker
 celery -A backend.app.tasks beat
 ```
 The worker schedules a nightly digest summarizing new chunks and maintains
-wiki-style backlinks between notes.
+wiki-style backlinks between notes. On Windows the combined `celery -B` mode is
+unsupported; starting the worker and beat separately avoids errors. If the
+logs show connection refusals to Redis, ensure the Redis server is running or
+update `REDIS_URL` to point to an accessible broker.
 
 ### Importing Data
 

--- a/docs/README-local-dev.md
+++ b/docs/README-local-dev.md
@@ -7,6 +7,7 @@ This short guide explains how to run the entire project locally without any pack
 - Python 3.11+
 - Node.js (for the Vue frontend)
 - The .NET 8 SDK (optional but recommended)
+- Redis server (for Celery tasks)
 
 ## Quick Start
 
@@ -34,6 +35,7 @@ If you prefer to run each component manually:
 
 ```bash
 # Backend
+python -m pip install --upgrade pip
 pip install -r backend/requirements.txt
 python -m backend.app.main
 
@@ -52,5 +54,25 @@ node ../server.js
 dotnet build src/ConsoleAppSolution.sln -c Release
 dotnet run --project src/ConsoleApp/ConsoleApp.csproj
 ```
+
+To run database migrations or other management commands, invoke them as modules:
+
+```bash
+python -m backend.app.manage <command>
+```
+
+Directly executing `manage.py` can raise an "attempted relative import with no known parent package" error.
+
+## Background tasks
+
+Celery uses Redis as its broker. Ensure a Redis server is running and start the worker and beat schedulers in separate terminals:
+
+```bash
+redis-server &   # or ensure the Redis service is running
+celery -A backend.app.tasks worker
+celery -A backend.app.tasks beat
+```
+
+On Windows the combined `celery -B` mode is unsupported; running the worker and beat separately avoids issues. If Celery logs connection refusals to `redis://localhost:6379/0`, verify that Redis is reachable or update `REDIS_URL`.
 
 The default UI is served at `http://localhost:5173` (or `http://localhost:8080` when serving the built bundle).

--- a/run_all.sh
+++ b/run_all.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -eEuo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -10,7 +10,6 @@ export LOG_FILE
 
 exec > >(tee -a "$LOG_FILE") 2>&1
 echo "=== run_all.sh started at $(date) ==="
-
 
 # Determine supported platform (Ubuntu/WSL or Windows)
 case "$(uname)" in
@@ -41,26 +40,45 @@ if [[ $PLATFORM == "ubuntu" && $EUID -ne 0 ]]; then
   fi
 fi
 
+free_port() {
+  local port=$1
+  if command -v lsof >/dev/null 2>&1 && lsof -ti tcp:"$port" >/dev/null 2>&1; then
+    lsof -ti tcp:"$port" | xargs kill -9 >/dev/null 2>&1 || true
+  fi
+}
+
+cleanup() {
+  if [[ -z "${CLEANED_UP:-}" ]]; then
+    CLEANED_UP=1
+    "$ROOT/frank_down.sh"
+    free_port 5173
+    free_port 8001
+    free_port 11434
+  fi
+}
 
 error_handler() {
   local exit_code=$?
   echo "Error on line $1: $2 (exit code $exit_code)" >&2
+  exit "$exit_code"
 }
+
+trap cleanup EXIT
 trap 'error_handler ${LINENO} "$BASH_COMMAND"' ERR
-trap "$ROOT/frank_down.sh" EXIT
 
-
+run_step() {
+  local desc="$1"; shift
+  echo "--- $desc ---"
+  "$@"
+}
 
 # Ensure Yarn is available and install dependencies via workspaces
 if ! command -v yarn >/dev/null 2>&1; then
-  echo "--- Yarn not found. Installing globally ---"
-  npm install -g yarn
+  run_step "Yarn not found. Installing globally" npm install -g yarn
 fi
-echo "--- Installing workspace dependencies with Yarn ---"
-(cd "$ROOT" && yarn install)
+run_step "Installing workspace dependencies with Yarn" bash -c "cd '$ROOT' && yarn install"
 
-echo "--- Building .NET console application ---"
-dotnet build "$ROOT/src/ConsoleAppSolution.sln" -c Release 2>&1 | tee "$LOG_DIR/dotnet-build.log" || true
+run_step "Building .NET console application" bash -c "dotnet build '$ROOT/src/ConsoleAppSolution.sln' -c Release 2>&1 | tee '$LOG_DIR/dotnet-build.log'"
 
 echo "--- Building Python backend ---"
 if [[ $PLATFORM == "windows" ]]; then
@@ -70,33 +88,48 @@ else
   PYTHON_BIN="python3"
   VENV_ACTIVATE="$ROOT/.venv/bin/activate"
 fi
-(
-  [ -d "$ROOT/.venv" ] || $PYTHON_BIN -m venv "$ROOT/.venv"
-  # shellcheck disable=SC1090
-  source "$VENV_ACTIVATE"
-  pip install --upgrade pip
-  pip install -r "$ROOT/backend/requirements.txt"
-  $PYTHON_BIN -m backend.app.manage migrate
-) 2>&1 | tee -a "$LOG_DIR/backend-build.log" || true
+run_step "Preparing Python environment" bash -c "[ -d '$ROOT/.venv' ] || $PYTHON_BIN -m venv '$ROOT/.venv'"
+# shellcheck disable=SC1090
+run_step "Installing backend dependencies" bash -c "source '$VENV_ACTIVATE' && pip install --upgrade pip && pip install -r '$ROOT/backend/requirements.txt' && $PYTHON_BIN -m backend.app.manage migrate 2>&1 | tee -a '$LOG_DIR/backend-build.log'"
 
 if [[ $PLATFORM == "ubuntu" ]]; then
-  echo "--- Running frank_up.sh ---"
-  "$ROOT/frank_up.sh"
+  run_step "Running frank_up.sh" "$ROOT/frank_up.sh"
 
-  echo "--- Installing frontend dependencies ---"
-  npm --prefix "$ROOT/app" install
-  echo "--- Starting ESBuild dev server ---"
-  node "$ROOT/app/esbuild.config.js" --serve \
-    >"$LOG_DIR/frontend.out.log" 2>"$LOG_DIR/frontend.err.log" &
-  FRONTEND_PID=$!
-  echo "$FRONTEND_PID" > "$LOG_DIR/frontend.pid"
+  run_step "Installing frontend dependencies" npm --prefix "$ROOT/app" install
+  start_frontend() {
+    node "$ROOT/app/esbuild.config.js" --serve >"$LOG_DIR/frontend.out.log" 2>"$LOG_DIR/frontend.err.log" &
+    echo $! > "$LOG_DIR/frontend.pid"
+  }
+  run_step "Starting ESBuild dev server" start_frontend
 else
-  echo "--- Running frank_up.ps1 ---"
-  powershell.exe -ExecutionPolicy Bypass -File "$ROOT/frank_up.ps1"
+  run_step "Running frank_up.ps1" powershell.exe -ExecutionPolicy Bypass -File "$ROOT/frank_up.ps1"
 fi
 
 echo "Logs directory: $LOG_DIR (backend.log, frontend.out.log, frontend.err.log, dotnet.log, etc.)"
 
+# Verify backend dev server is responding
+echo "--- Checking backend availability ---"
+backend_up=""
+for i in {1..15}; do
+  if curl -fsS http://localhost:8001/api/hello >/dev/null 2>&1; then
+    echo "Backend responding on http://localhost:8001"
+    backend_up=1
+    break
+  fi
+  sleep 1
+done
+if [[ -z $backend_up ]]; then
+  echo "Backend not responding on http://localhost:8001" >&2
+  exit 1
+fi
+
+# Verify Celery worker and beat are running
+for pid_file in "$LOG_DIR/celery_worker.pid" "$LOG_DIR/celery_beat.pid"; do
+  if [[ ! -s $pid_file ]] || ! kill -0 "$(cat "$pid_file")" >/dev/null 2>&1; then
+    echo "Required Celery process missing: $pid_file" >&2
+    exit 1
+  fi
+done
 
 # Verify frontend dev server is responding
 echo "--- Checking frontend availability ---"
@@ -112,7 +145,6 @@ done
 if [[ -z $frontend_up ]]; then
   echo "Frontend not responding on http://localhost:5173. See $LOG_DIR/frontend.out.log and $LOG_DIR/frontend.err.log" >&2
 fi
-
 
 # Helper to open the default browser on the correct platform
 open_browser() {
@@ -164,4 +196,3 @@ echo "Press Ctrl+C to stop services."
 while true; do
   sleep 1 || break
 done
-


### PR DESCRIPTION
## Summary
- document upgrading pip before installing backend dependencies
- explain running management commands with `python -m` to avoid relative import errors
- add Redis and separate Celery worker/beat instructions for background tasks
- ensure run script validates services and cleans up ports on failure

## Testing
- `bash scripts/test_pipeline.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aa22cd5cec8333b091e3aa16bae42a