### PR TITLE
Use venv paths and add Redis/Ollama health checks

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,6 @@
 PORT=8001
 DB_URL=sqlite:///app.db
 MODEL_PATH=models/model.bin
+MODEL=llama3
+CELERY_BROKER_URL=redis://localhost:6379/0
+CELERY_RESULT_BACKEND=redis://localhost:6379/0

--- a/backend/app/services/base.py
+++ b/backend/app/services/base.py
@@ -7,7 +7,6 @@ from typing import Any, Callable
 
 from sqlalchemy.orm import Session
 
-from ..llm import LLMClient
 
 class UnitOfWork:
     """Collects database changes and flushes them on teardown."""
@@ -46,7 +45,7 @@ def get_uow(db: Session) -> UnitOfWork:
 class CachedLLMService(ABC):
     """Mixin for services that interact with an LLM with LRU caching."""
 
-    def __init__(self, llm: LLMClient, cache_size: int = 128) -> None:
+    def __init__(self, llm: Any, cache_size: int = 128) -> None:
         self._llm = llm
         self._hit = False
 

--- a/backend/app/services/summarization_service.py
+++ b/backend/app/services/summarization_service.py
@@ -1,11 +1,11 @@
 from sqlalchemy.orm import Session
 
-from ..llm import LLMClient
+from ..llm import OllamaLLM
 from . import CachedLLMService
 from ..models import Entry
 
 class SummarizationService(CachedLLMService):
-    def __init__(self, llm: LLMClient):
+    def __init__(self, llm: OllamaLLM):
         super().__init__(llm)
 
     def summarize_pending_entries(self, db: Session) -> None:

--- a/run_all.sh
+++ b/run_all.sh
@@ -126,7 +126,7 @@ fi
 # Verify Celery worker and beat are running
 for pid_file in "$LOG_DIR/celery_worker.pid" "$LOG_DIR/celery_beat.pid"; do
   if [[ ! -s $pid_file ]] || ! kill -0 "$(cat "$pid_file")" >/dev/null 2>&1; then
-    echo "Required Celery process missing: $pid_file" >&2
+    echo "Required Celery process missing: $pid_file. See logs/celery_worker.err.log and logs/celery_worker.out.log" >&2
     exit 1
   fi
 done


### PR DESCRIPTION
## Summary
- resolve virtualenv python/celery paths explicitly in frank_up.ps1
- wait for Redis and Ollama with retry loops before launching Celery
- switch Celery config to env-based Redis URLs and add robust Ollama client
- improve Celery failure message and require broker/backend env vars

## Testing
- `pytest` *(fails: Ollama unavailable)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab6947b2648333a4afe3314488e7e5