### PR TITLE
Improve startup checks and Ollama initialization

### DIFF
--- a/backend/app/llm.py
+++ b/backend/app/llm.py
@@ -3,23 +3,30 @@ import logging
 import requests
 from langchain_ollama import OllamaLLM as LangchainOllama
 
-class OllamaLLM:
-    def __init__(self, model: str = "llama3", retries: int = 3, backoff: float = 2.0):
-        self.model = model
+
+class OllamaLLM(LangchainOllama):
+    """LangChain Ollama client with retry logic.
+
+    Tries to connect to the local Ollama service up to ``retries`` times before
+    giving up.  If the service is unavailable a :class:`RuntimeError` is raised
+    so that callers fail fast instead of silently falling back to a dummy
+    implementation.
+    """
+
+    def __init__(self, model: str = "llama3", retries: int = 3, backoff: float = 2.0, **kwargs):
         last_err = None
         for i in range(retries):
             try:
                 r = requests.get("http://localhost:11434", timeout=5)
                 r.raise_for_status()
-                self._client = LangchainOllama(model=self.model)
-                logging.info("Ollama connected on attempt %d", i+1)
+                super().__init__(model=model, **kwargs)
+                logging.info("Ollama connected on attempt %d", i + 1)
                 return
             except Exception as e:  # pragma: no cover - network errors
                 last_err = e
-                logging.warning("Ollama connect failed (attempt %d/%d): %s", i+1, retries, e)
+                logging.warning(
+                    "Ollama connect failed (attempt %d/%d): %s", i + 1, retries, e
+                )
                 time.sleep(backoff)
         logging.error("Ollama unavailable after %d attempts: %s", retries, last_err)
         raise RuntimeError(f"Ollama unavailable: {last_err}")
-
-    def invoke(self, prompt: str) -> str:
-        return self._client.invoke(prompt)

--- a/backend/app/services/agent_service.py
+++ b/backend/app/services/agent_service.py
@@ -2,8 +2,8 @@
 from fastapi import APIRouter, HTTPException, Body
 from langchain_community.agent_toolkits.sql.base import create_sql_agent
 from langchain_community.utilities import SQLDatabase
-from langchain_community.llms import Ollama
 from langchain_experimental.sql import SQLDatabaseChain
+from ..llm import OllamaLLM
 
 from ..db import engine
 from ..config import Settings
@@ -18,7 +18,7 @@ def get_agent():
     global _AGENT
     if _AGENT is None:
         db = SQLDatabase(engine)
-        llm = Ollama(model=settings.model)
+        llm = OllamaLLM(model=settings.model)
         _AGENT = create_sql_agent(llm=llm, db=db, agent_type="openai-tools")
     return _AGENT
 
@@ -27,7 +27,7 @@ def get_chain():
     global _CHAIN
     if _CHAIN is None:
         db = SQLDatabase(engine)
-        llm = Ollama(model=settings.model)
+        llm = OllamaLLM(model=settings.model)
         _CHAIN = SQLDatabaseChain.from_llm(llm, db, return_intermediate_steps=True)
     return _CHAIN
 

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import json
 
 from fastapi import APIRouter, Body, HTTPException
-from langchain_community.llms import Ollama
+from ..llm import OllamaLLM
 from ..config import Settings
 
 router = APIRouter(tags=["chat"], prefix="/chat")
@@ -14,12 +14,12 @@ _CACHE_FILE = Path(__file__).resolve().parents[1] / "data" / "chat_cache.json"
 
 
 class ChatService:
-    _llm: Ollama | None = None
+    _llm: OllamaLLM | None = None
     _cache: dict[str, str] | None = None
 
     def __init__(self) -> None:
         if self._llm is None:
-            self._llm = Ollama(model=settings.model)
+            self._llm = OllamaLLM(model=settings.model)
         if self._cache is None:
             self._cache = _load_cache()
 

--- a/backend/app/services/qa_service.py
+++ b/backend/app/services/qa_service.py
@@ -7,8 +7,9 @@ from langchain_community.embeddings import OllamaEmbeddings
 from langchain.chains import RetrievalQA
 from langchain.prompts import PromptTemplate
 from langchain.callbacks.streaming_aiter import AsyncIteratorCallbackHandler
-from langchain_community.llms import Ollama
 import asyncio
+
+from ..llm import OllamaLLM
 
 from ..config import Settings
 
@@ -31,7 +32,7 @@ def _chain():
         "{source_path}#{line}.\n{question}"
     )
     prompt = PromptTemplate.from_template(template)
-    llm = Ollama(model=settings.model, streaming=True)
+    llm = OllamaLLM(model=settings.model, streaming=True)
     return RetrievalQA.from_chain_type(
         llm=llm,
         retriever=retriever,

--- a/backend/app/services/sql_service.py
+++ b/backend/app/services/sql_service.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Body, HTTPException, Depends
 from langchain_community.agent_toolkits.sql.base import create_sql_agent
 from langchain_community.utilities import SQLDatabase
-from langchain_community.llms import Ollama
+from ..llm import OllamaLLM
 from ..config import Settings
 
 from ..db import engine
@@ -13,7 +13,7 @@ settings = Settings()
 
 class SQLService(CachedLLMService):
     def __init__(self):
-        super().__init__(Ollama(model=settings.model))
+        super().__init__(OllamaLLM(model=settings.model))
         self._db = SQLDatabase(engine)
         self._agent = create_sql_agent(llm=self._llm, db=self._db, agent_type="openai-tools")
 

--- a/backend/app/services/trivia_service.py
+++ b/backend/app/services/trivia_service.py
@@ -6,7 +6,7 @@ from langchain_community.document_loaders import UnstructuredMarkdownLoader
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.vectorstores import Chroma
 from langchain_community.embeddings import OllamaEmbeddings
-from langchain_community.llms import Ollama
+from ..llm import OllamaLLM
 from ..config import Settings
 
 from . import CachedLLMService
@@ -19,7 +19,7 @@ settings = Settings()
 
 class TriviaService(CachedLLMService):
     def __init__(self):
-        super().__init__(Ollama(model=settings.model))
+        super().__init__(OllamaLLM(model=settings.model))
         loader = UnstructuredMarkdownLoader(str(DATA_FILE))
         docs = loader.load()
         splitter = RecursiveCharacterTextSplitter(chunk_size=512, chunk_overlap=50)

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -4,11 +4,11 @@ import json
 from pathlib import Path
 
 from celery import Celery
-from langchain_community.llms import Ollama
 
 from .db import SessionLocal
 from .models import User
 from .config import Settings
+from .llm import OllamaLLM
 
 celery_app = Celery("worker", broker="redis://localhost:6379/0")
 settings = Settings()
@@ -47,7 +47,7 @@ def summarize_new_users():
     if not users:
         return "No new users"
 
-    llm = Ollama(model=settings.model)
+    llm = OllamaLLM(model=settings.model)
     content = "\n".join(u.username for u in users)
     summary = llm.invoke(f"Summarize the following new users:\n{content}")
 


### PR DESCRIPTION
## Summary
- add Redis and Ollama health checks with automatic reinstall to Windows startup script
- wrap LangChain Ollama client with retry logic and use it across services
- lazy-load summarization service for Celery tasks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab6ea7304c8333afa2af8172ed421f