### PR TITLE
Quote reserved DB columns and adjust PowerShell bootstrap

### DIFF
--- a/frank_up.ps1
+++ b/frank_up.ps1
@@ -130,7 +130,7 @@ for ($i=0; $i -lt 30; $i++) {
   }
 }
 
-function Test-Port($hostname,$portNumber){ try{ (New-Object Net.Sockets.TcpClient).Connect($hostname,$portNumber) ; return $true } catch { return $false } }
+function Test-Port($hostname, $port){ try{ (New-Object Net.Sockets.TcpClient).Connect($hostname,$port) ; return $true } catch { return $false } }
 
 # Wait for Redis (3 tries)
 $redisOk = $false

--- a/src/Infrastructure/QueryBuilders/EntryQueryBuilder.cs
+++ b/src/Infrastructure/QueryBuilders/EntryQueryBuilder.cs
@@ -15,7 +15,7 @@ public class EntryQueryBuilder
 
     public (string Sql, DynamicParameters Parameters) Build()
     {
-        var sb = new StringBuilder("SELECT id as Id, user_id as UserId, title as Title, \"group\" as Group, content as Content, summary as Summary, is_summarised as IsSummarised, tags as Tags, created_at as CreatedAt FROM entries");
+        var sb = new StringBuilder("SELECT id as Id, user_id as UserId, title as Title, \"group\" as \"Group\", content as Content, summary as Summary, is_summarised as IsSummarised, tags as Tags, created_at as CreatedAt FROM entries");
         var conditions = new List<string>();
         var parameters = new DynamicParameters();
         if (_options.Tags != null && _options.Tags.Any())

--- a/src/Infrastructure/Repositories/BaseRepository.cs
+++ b/src/Infrastructure/Repositories/BaseRepository.cs
@@ -31,10 +31,10 @@ public abstract class BaseRepository<T> where T : BaseEntity
         var props = typeof(T).GetProperties()
             .Where(p => p.Name != nameof(BaseEntity.Id))
             .ToArray();
-        var columns = string.Join(", ", props.Select(p => ToSnakeCase(p.Name)));
+        var columns = string.Join(", ", props.Select(p => $"\"{ToSnakeCase(p.Name)}\""));
         var parameters = string.Join(", ", props.Select(p => $"@{p.Name}"));
         _insertSql = $"INSERT INTO {tableName} ({columns}) VALUES ({parameters}); SELECT last_insert_rowid();";
-        var sets = string.Join(", ", props.Select(p => $"{ToSnakeCase(p.Name)} = @{p.Name}"));
+        var sets = string.Join(", ", props.Select(p => $"\"{ToSnakeCase(p.Name)}\" = @{p.Name}"));
         _updateSql = $"UPDATE {tableName} SET {sets} WHERE id = @Id";
     }
 


### PR DESCRIPTION
## Summary
- Quote reserved column names in generic repository to support SQLite keywords like `group`
- Escape `group` alias in query builder
- Rename Test-Port parameters in `frank_up.ps1` to avoid shadowing built-in variables

## Testing
- `./scripts/install_deps.sh` *(fails: Required command 'ollama' not installed)*
- `./scripts/run_redis.sh` *(fails: Redis did not start)*
- `./scripts/run_net.sh`
- `curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8001/api/hello`
- `./scripts/run_celery.sh` *(fails: Celery failed to start or cannot reach Redis)*
- `./scripts/run_frontend.sh`
- `curl -s -o /dev/null -w "%{http_code}\n" http://localhost:5173`
- `./scripts/run_ollama.sh` *(fails: ollama not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7d39a2288333bca8a58f965c60b5