### PR TITLE
Fix entry schema mismatch and add error handling

### DIFF
--- a/src/ConsoleApp/Program.cs
+++ b/src/ConsoleApp/Program.cs
@@ -11,6 +11,7 @@ var configuration = new ConfigurationBuilder()
     .Build();
 
 var services = new ServiceCollection();
+services.AddLogging();
 
 var connectionString = configuration.GetConnectionString("Default") ?? "Data Source=app.db";
 services.AddSingleton(new SqliteConnectionFactory(connectionString));

--- a/src/Infrastructure.Tests/Infrastructure.Tests.csproj
+++ b/src/Infrastructure.Tests/Infrastructure.Tests.csproj
@@ -5,6 +5,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <ProjectReference Include="..\Infrastructure\Infrastructure.csproj" />
     <ProjectReference Include="..\Domain\Domain.csproj" />
   </ItemGroup>

--- a/src/Infrastructure.Tests/SchemaMigrationTests.cs
+++ b/src/Infrastructure.Tests/SchemaMigrationTests.cs
@@ -4,6 +4,8 @@ using Dapper;
 using Infrastructure.Data;
 using Infrastructure.Repositories;
 using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Reflection;
 using Xunit;
 
 public class SchemaMigrationTests
@@ -30,8 +32,10 @@ public class SchemaMigrationTests
         var factory = new SqliteConnectionFactory(connString);
         var db = new LoggingDataAccess(factory);
         await db.InitializeAsync();
-        var entryRepo = new EntryRepository(db);
+        var entryRepo = new EntryRepository(db, NullLogger<EntryRepository>.Instance);
         await entryRepo.InitializeAsync();
+        typeof(UserRepository).GetField("_schemaEnsured", BindingFlags.NonPublic | BindingFlags.Static)!
+            .SetValue(null, false);
         var userRepo = new UserRepository(db);
         await userRepo.InitializeAsync();
 

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Infrastructure/Repositories/EntryRepository.cs
+++ b/src/Infrastructure/Repositories/EntryRepository.cs
@@ -3,13 +3,18 @@ using Domain.Entities;
 using Domain.Interfaces;
 using Infrastructure.Data;
 using Infrastructure.QueryBuilders;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.Repositories;
 
 public class EntryRepository : BaseRepository<Entry>, IEntryRepository
 {
-    public EntryRepository(LoggingDataAccess db) : base(db, "entries")
+    private readonly ILogger<EntryRepository> _logger;
+
+    public EntryRepository(LoggingDataAccess db, ILogger<EntryRepository> logger) : base(db, "entries")
     {
+        _logger = logger;
     }
 
     public async Task InitializeAsync()
@@ -22,8 +27,8 @@ public class EntryRepository : BaseRepository<Entry>, IEntryRepository
             content TEXT NOT NULL,
             summary TEXT NOT NULL DEFAULT '',
             is_summarised INTEGER NOT NULL DEFAULT 0,
-            tags TEXT,
-            created_at TEXT NOT NULL,
+            tags TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ')),
             FOREIGN KEY(user_id) REFERENCES users(id)
         );";
         await _db.ExecuteAsync(sql);
@@ -50,8 +55,28 @@ public class EntryRepository : BaseRepository<Entry>, IEntryRepository
         {
             await _db.ExecuteAsync("ALTER TABLE entries ADD COLUMN is_summarised INTEGER NOT NULL DEFAULT 0;");
         }
+        if (await _db.ExecuteScalarAsync<long>(check, new { Name = "tags" }) == 0)
+        {
+            await _db.ExecuteAsync("ALTER TABLE entries ADD COLUMN tags TEXT NOT NULL DEFAULT '';");
+        }
+        if (await _db.ExecuteScalarAsync<long>(check, new { Name = "created_at" }) == 0)
+        {
+            await _db.ExecuteAsync("ALTER TABLE entries ADD COLUMN created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ'));");
+        }
     }
 
+    public override async Task<int> AddAsync(Entry entity)
+    {
+        try
+        {
+            return await base.AddAsync(entity);
+        }
+        catch (SqliteException ex)
+        {
+            _logger.LogError(ex, "Database error while inserting entry.");
+            throw new InvalidOperationException("Failed to save entry.", ex);
+        }
+    }
 
     public async Task<IEnumerable<Entry>> QueryAsync(EntryQueryOptions options)
     {


### PR DESCRIPTION
## Summary
- ensure `entries` table includes title, group, summary, tags, and other fields with default values
- add defensive logging and error handling when inserting entries
- wire up logging services and tests

## Testing
- `dotnet test ConsoleAppSolution.sln`

------
https://chatgpt.com/codex/tasks/task_e_68ab878a19f48333b29623b7beae964e