### PR TITLE
Ensure entry schema matches .NET

### DIFF
--- a/backend/app/manage.py
+++ b/backend/app/manage.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text, inspect
 from sqlalchemy.orm import sessionmaker
 from .config import Settings
 from . import models
@@ -12,7 +12,46 @@ Session = sessionmaker(bind=engine)
 SAMPLE_MD = Path(__file__).resolve().parents[1] / 'data' / 'sample.md'
 
 def migrate():
+    """Create or upgrade the SQLite schema.
+
+    ``Base.metadata.create_all`` only creates tables; it does not add missing
+    columns on existing databases.  Development databases created before the
+    introduction of the ``title``, ``group``, ``summary`` and
+    ``is_summarised`` columns would therefore lack these fields and cause the
+    .NET application to crash.  Here we detect the legacy schema and apply the
+    minimal ``ALTER TABLE`` statements to bring it up to date.
+    """
+
     Base.metadata.create_all(bind=engine)
+
+    inspector = inspect(engine)
+    existing = {col["name"] for col in inspector.get_columns("entries")}
+    with engine.begin() as conn:
+        if "title" not in existing:
+            conn.execute(
+                text(
+                    "ALTER TABLE entries ADD COLUMN title TEXT NOT NULL DEFAULT ''"
+                )
+            )
+        if "group" not in existing:
+            # 'group' is a reserved keyword in SQL, hence the quoting
+            conn.execute(
+                text(
+                    'ALTER TABLE entries ADD COLUMN "group" TEXT NOT NULL DEFAULT \'\''
+                )
+            )
+        if "summary" not in existing:
+            conn.execute(
+                text(
+                    "ALTER TABLE entries ADD COLUMN summary TEXT NOT NULL DEFAULT ''"
+                )
+            )
+        if "is_summarised" not in existing:
+            conn.execute(
+                text(
+                    "ALTER TABLE entries ADD COLUMN is_summarised BOOLEAN NOT NULL DEFAULT 0"
+                )
+            )
 
 
 def seed():

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -21,7 +21,10 @@ class Entry(Base):
     group = Column(String, nullable=True)
     content = Column(String, nullable=False)
     summary = Column(String, nullable=True)
-    summarized = Column(Boolean, default=False)
+    # Align column name with the .NET application's schema which expects
+    # ``is_summarised``.  Expose it in Python as ``summarized`` to keep the
+    # existing API and model attribute names stable.
+    summarized = Column("is_summarised", Boolean, default=False)
 
 
 class File(Base):


### PR DESCRIPTION
## Summary
- align Python model with .NET's `is_summarised` column
- add a migration step to insert `title`, `group`, `summary`, and `is_summarised` columns if missing

## Testing
- `pytest -q`
- `dotnet test src/Infrastructure.Tests/Infrastructure.Tests.csproj`
- `scripts/run_backend.sh`
- `scripts/run_celery.sh`
- `scripts/run_frontend.sh`
- `scripts/run_ollama.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ab90e780c48333bc576ec10cb73a81